### PR TITLE
typos

### DIFF
--- a/src/exercises/ez-1-6.xml
+++ b/src/exercises/ez-1-6.xml
@@ -6,19 +6,19 @@
   </exercise>
 
   <exercise xml:id="ez-1-6-WW2">
-    <webwork source="LLibrary/Michigan/Chap2Sec5/Q03.pg" />
+    <webwork source="Library/Michigan/Chap2Sec5/Q03.pg" />
   </exercise>
 
   <exercise xml:id="ez-1-6-WW3">
-    <webwork source="LLibrary/Michigan/Chap2Sec5/Q15.pg" />
+    <webwork source="Library/Michigan/Chap2Sec5/Q15.pg" />
   </exercise>
 
   <exercise xml:id="ez-1-6-WW4">
-    <webwork source="LLibrary/Michigan/Chap2Sec5/Q16.pg" />
+    <webwork source="Library/Michigan/Chap2Sec5/Q16.pg" />
   </exercise>
 
   <exercise xml:id="ez-1-6-WW5">
-    <webwork source="LLibrary/Michigan/Chap2Sec5/Q21.pg" />
+    <webwork source="Library/Michigan/Chap2Sec5/Q21.pg" />
   </exercise>
 
 <exercise>

--- a/src/exercises/ez-2-5.xml
+++ b/src/exercises/ez-2-5.xml
@@ -18,7 +18,7 @@
   </exercise>
 
   <exercise xml:id="ez-2-5-WW5">
-    <webwork source="LLibrary/Michigan/Chap3Sec4/Q53.pg" />
+    <webwork source="Library/Michigan/Chap3Sec4/Q53.pg" />
   </exercise>
 
   <exercise xml:id="ez-2-5-WW6">

--- a/src/exercises/ez-3-5.xml
+++ b/src/exercises/ez-3-5.xml
@@ -6,7 +6,7 @@
   </exercise>
 
   <exercise xml:id="ez-3-5-WW2">
-    <webwork source="LLibrary/270/setDerivatives8RelatedRates/s2_8_21.pg" />
+    <webwork source="Library/270/setDerivatives8RelatedRates/s2_8_21.pg" />
   </exercise>
 
   <exercise xml:id="ez-3-5-WW3">

--- a/src/exercises/ez-4-1.xml
+++ b/src/exercises/ez-4-1.xml
@@ -10,7 +10,7 @@
   </exercise>
 
   <exercise xml:id="ez-4-1-WW3">
-    <webwork source="LLibrary/Michigan/Chap5Sec1/Q21.pg" />
+    <webwork source="Library/Michigan/Chap5Sec1/Q21.pg" />
   </exercise>
 
   <exercise xml:id="ez-4-1-WW4">

--- a/src/exercises/ez-5-4.xml
+++ b/src/exercises/ez-5-4.xml
@@ -14,7 +14,7 @@
   </exercise>
 
   <exercise xml:id="ez-5-4-WW4">
-    <webwork source="LLibrary/Rochester/setIntegrals15ByParts/sc5_6_15.pg" />
+    <webwork source="Library/Rochester/setIntegrals15ByParts/sc5_6_15.pg" />
   </exercise>
 
       <exercise>

--- a/src/exercises/ez-7-2.xml
+++ b/src/exercises/ez-7-2.xml
@@ -14,7 +14,7 @@
   </exercise>
 
   <exercise xml:id="ez-7-2-WW4">
-    <webwork source="LLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_1.pg" />
+    <webwork source="Library/Rochester/setDiffEQ6AutonomousStability/ur_de_6_1.pg" />
   </exercise>
 
   <exercise xml:id="ez-7-2-WW5">


### PR DESCRIPTION
Some WeBWorK problems were coming up empty and it was because of typos in their file paths.