### PR TITLE
missing closing p tag

### DIFF
--- a/src/sec-1-1-vel.xml
+++ b/src/sec-1-1-vel.xml
@@ -159,6 +159,7 @@
       <statement>
         <p>
         The position function for a falling ball is given by <m>s(t) = 16 - 16t^2</m> (where <m>s</m> is measured in feet and <m>t</m> in seconds).
+        </p>
 
         <p>
           <ol label="a">


### PR DESCRIPTION

There was a missing closing p tag.  I found it when trying to make the html.

The current edition version was used for this html:

https://activecalculus.org/single_test_2/sec-1-1-vel.html

I am going to accept this right away, so that I can email Kathy.