### PR TITLE
License text update

### DIFF
--- a/src/colophon.xml
+++ b/src/colophon.xml
@@ -38,7 +38,7 @@
           <image xml:id="CC-BY-SA-license" source="images/CC-BY-SA-license" />
         </sidebyside>
 
-        that may appear in other locations in the text shows that the work is licensed with the Creative Commons and that the work may be used for free by any party so long as attribution is given to the author(s). Full details may be found by visiting <url href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</url>  or sending a letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
+        that may appear in other locations in the text shows that the work is licensed with the Creative Commons and that the work may be used for free by any party so long as attribution is given to the author(s) and if the material is modified, the resulting contributions are distributed under the same license as this original. Full details may be found by visiting <url href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</url>  or sending a letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
       </shortlicense>
     </copyright>
   </colophon>


### PR DESCRIPTION
There's some repetition of language surrounding what CC-BY-SA means in the `shortlicense`, and the second passage doesn't mention the SA part, so I updated that.