### PR TITLE
idx entries should not be the entire p-paragraph

### DIFF
--- a/src/sec-1-6-second-d.xml
+++ b/src/sec-1-6-second-d.xml
@@ -156,9 +156,7 @@
 
   <subsection>
     <title>The Second Derivative</title>
-    <p>
           <idx><h>second derivative</h></idx>
-    </p>
 
     <p>
       We are now accustomed to investigating the behavior of a function by examining its derivative.

--- a/src/sec-1-7-lim-cont-diff.xml
+++ b/src/sec-1-7-lim-cont-diff.xml
@@ -164,9 +164,7 @@
 
   <subsection>
     <title>Being continuous at a point</title>
-    <p>
           <idx><h>continuous</h></idx>
-    </p>
 
     <p>
       Intuitively,
@@ -273,9 +271,7 @@
 
   <subsection>
     <title>Being differentiable at a point</title>
-    <p>
           <idx><h>differentiable</h></idx>
-    </p>
 
     <p>
       We recall that a function <m>f</m> is said to be differentiable at <m>x = a</m> if <m>f'(a)</m> exists.

--- a/src/sec-1-8-tan-line-approx.xml
+++ b/src/sec-1-8-tan-line-approx.xml
@@ -65,9 +65,7 @@
 
   <subsection>
     <title>The tangent line</title>
-    <p>
           <idx><h>tangent line</h><h>equation</h></idx>
-    </p>
 
     <p>
       Given a function <m>f</m> that is differentiable at <m>x = a</m>,
@@ -101,9 +99,7 @@
 
   <subsection>
     <title>The local linearization</title>
-    <p>
           <idx><h>local linearization</h></idx>
-    </p>
 
     <p>
       A slight change in perspective and notation will enable us to be more precise in discussing how the tangent line approximates <m>f</m> near <m>x = a</m>.

--- a/src/sec-2-4-other-trig.xml
+++ b/src/sec-2-4-other-trig.xml
@@ -103,9 +103,7 @@
 
   <subsection>
     <title>Derivatives of the cotangent, secant, and cosecant functions</title>
-    <p>
           <idx><h>cotangent</h></idx> <idx><h>secant</h></idx> <idx><h>cosecant</h></idx>
-    </p>
 
     <p>
       In <xref ref="PA-2-4">Preview Activity</xref>,

--- a/src/sec-7-1-diff-eq-intro.xml
+++ b/src/sec-7-1-diff-eq-intro.xml
@@ -67,9 +67,7 @@
 
   <subsection>
     <title>What is a differential equation?</title>
-    <p>
           <idx><h>differential equation</h></idx>
-    </p>
 
     <p>
       A differential equation is an equation that describes the derivative,
@@ -192,9 +190,7 @@
 
   <subsection>
     <title>Solving a differential equation</title>
-    <p>
           <idx><h>differential equation</h><h>solution</h></idx>
-    </p>
 
     <p>
       A differential equation describes the derivative,

--- a/src/sec-7-4-separable.xml
+++ b/src/sec-7-4-separable.xml
@@ -100,9 +100,7 @@
 
   <subsection>
     <title>Solving separable differential equations</title>
-    <p>
           <idx><h>separable</h></idx>
-    </p>
 
     <p>
       Before we discuss a general approach to solving a separable differential equation,


### PR DESCRIPTION
When a p-paragraph contains only idx entries, then the index does not function properly.
I removed the surrounding p tags in those cases.