### PR TITLE
HTML build updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ pg:
 acs-extraction:
 	install -d $(WWOUT)
 	-rm $(WWOUT)/webwork-representations.ptx
-	PYTHONWARNINGS=module $(MB)/pretext/pretext -c webwork -d $(WWOUT) -s $(SERVER) $(MAINFILE)
+	$(MB)/pretext/pretext -c webwork -d $(WWOUT) -s $(SERVER) $(MAINFILE)
 
 #  Make a new PTX file from the source tree, with webwork elements replaced
 #  by the webwork-reps from webwork-extraction.xml. (So run the above at
@@ -146,10 +146,10 @@ html:
 	install -b xsl/acs-html.xsl $(MBUSR)
 	install -b xsl/acs-common.xsl $(MBUSR)
 	-rm $(HTMLOUT)/*.html
-	cp -a $(IMAGESOUT) $(HTMLOUT)
+	cp -a $(WWOUT)/webwork*image* $(HTMLOUT)/images
 	cp -a $(IMAGESSRC) $(HTMLOUT)
 	cd $(HTMLOUT); \
-	xsltproc -xinclude -stringparam publisher $(PRJ)/pub/html.xml $(MBUSR)/acs-html.xsl $(MAINFILE)
+	xsltproc -xinclude -stringparam publisher $(PRJ)/pub/publication.xml $(MBUSR)/acs-html.xsl $(MAINFILE)
 
 # make all the image files in svg format
 images:

--- a/pub/html.xml
+++ b/pub/html.xml
@@ -1,7 +1,0 @@
-<publication>
-  <source webwork-problems="../output/webwork-extraction/webwork-representations.ptx"/>
-  <html>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
-    <css colors="blue_grey" />
-  </html>
-</publication>

--- a/pub/publication.xml
+++ b/pub/publication.xml
@@ -1,0 +1,15 @@
+<publication>
+  <source webwork-problems="../output/webwork-extraction/webwork-representations.ptx"/>
+  <html>
+    <search google-cx="015103900096539427448:ngwuia10qci" />
+    <css colors="blue_grey" />
+    <!-- Examples and exercises are knowlized by default -->
+    <!-- We disable this behavior  -->
+    <knowl example="no" exercise-divisional="no" exercise-inline="no" />
+  </html>
+  <latex sides="two" />
+  <common>
+    <!-- List Chapters and Sections in sidebar Table of Contents -->
+    <tableofcontents level="2" /> 
+  </common>
+</publication>

--- a/src/titlepage.xml
+++ b/src/titlepage.xml
@@ -41,8 +41,8 @@
     <title>Production Editor</title>
     <author>
       <personname>Mitchel T. Keller</personname>
-      <department>Department of Mathematics</department>
-      <institution>Morningside College</institution>
+      <department>Department of Natural and Mathematical Sciences</department>
+      <institution>Morningside University</institution>
       <email>mitch@rellek.net</email>
     </author>
   </credit>

--- a/xsl/acs-common.xsl
+++ b/xsl/acs-common.xsl
@@ -23,12 +23,9 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<!-- List Chapters and Sections in printed Table of Contents -->
-<xsl:param name="toc.level" select="'2'" />
 
-<!-- Set font size and two-sided mode -->
+<!-- Set font size  -->
 <xsl:param name="latex.font.size" select="'10pt'" />
-<xsl:param name="latex.sides" select="'two'" />
 <xsl:param name="latex.pageref" select="'no'" />
 
 <!-- Font configuration should be consistent -->

--- a/xsl/acs-html.xsl
+++ b/xsl/acs-html.xsl
@@ -22,14 +22,6 @@
 <!-- Assumes next file can be found in mathbook/user, so it must be copied there -->
 <xsl:import href="acs-common.xsl" />
 
-<!-- List Chapters and Sections in sidebar Table of Contents -->
-<xsl:param name="toc.level" select="'2'" />
-
-<!-- Examples and inline exercises are knowlized by default -->
-<!-- We disable this behavior  -->
-<xsl:param name="html.knowl.example" select="'no'" />
-<xsl:param name="html.knowl.exercise.inline" select="'no'" />
-
 <!-- Exercises have hint (sporadically), answer, and solution -->
 <xsl:param name="exercise.divisional.statement" select="'yes'" />
 <xsl:param name="exercise.divisional.hint" select="'yes'" />
@@ -46,6 +38,5 @@
 
 <!-- Specify options for WeBWorK exercises -->
 <xsl:param name="webwork.divisional.static" select="'no'" />
-<xsl:param name="html.knowl.exercise.sectional" select="'no'" />
 
 </xsl:stylesheet>


### PR DESCRIPTION
This updates so that we can use `make html` against the PreTeXt source at `32a8bffa650dec2227b3e470037d60cc656c774f`.