### PR TITLE
Fix typos in answer/solution to two activities.

### DIFF
--- a/source/activities/act-3-4-4.xml
+++ b/source/activities/act-3-4-4.xml
@@ -42,7 +42,7 @@
   <answer permid="lmo">
     <p permid="Ckz">
       <m>A(1.19606) \approx 2.2018</m> is the absolute maximum cross-sectional area,
-      which leads to the absolute maximum volueme.
+      which leads to the absolute maximum volume.
     </p>
   </answer>
   <solution permid="Fff">

--- a/source/activities/act-6-1-1.xml
+++ b/source/activities/act-6-1-1.xml
@@ -94,7 +94,7 @@
 
         <li permid="ARY">
           <p permid="vcM">
-            <m> A = \int_{-\sqrt{20}/3}^{\sqrt{20}/3} ((12-x^2)-(x^2-8)) \, dx \frac{160 \sqrt{\frac{5}{3}}}{3} \approx 68.853</m>.
+            <m> A = \int_{-\sqrt{20}/3}^{\sqrt{20}/3} ((12-2x^2)-(x^2-8)) \, dx \frac{160 \sqrt{\frac{5}{3}}}{3} \approx 68.853</m>.
           </p>
         </li>
 
@@ -161,12 +161,12 @@
 
           <p permid="fTO">
             Slicing the region with thin vertical rectangles,
-            a typical rectangle's height is given by <m>(12-x^2)-(x^2-8)</m>,
-            and thus the area of such a slice is <m>A_{\text{rect} } = ((12-x^2)-(x^2-8)) \Delta x</m>.
+            a typical rectangle's height is given by <m>(12-2x^2)-(x^2-8)</m>,
+            and thus the area of such a slice is <m>A_{\text{rect} } = ((12-2x^2)-(x^2-8)) \Delta x</m>.
             Hence,
             the area of the region bounded by the two curves is
             <me permid="BBS">
-              A = \int_{-\sqrt{20}/3}^{\sqrt{20}/3} ((12-x^2)-(x^2-8)) \, dx
+              A = \int_{-\sqrt{20}/3}^{\sqrt{20}/3} ((12-2x^2)-(x^2-8)) \, dx
             </me>.
             Evaluating the integral,
             we find <m>A = \frac{160 \sqrt{\frac{5}{3}}}{3} \approx 68.853</m>.

--- a/source/activities/act-6-5-3.xml
+++ b/source/activities/act-6-5-3.xml
@@ -120,7 +120,7 @@
 
         <li permid="SOY">
           <p permid="Kfg">
-            <m> \int_0^4 \frac{1}{\sqrt{4-x}} dx = 4 </m>
+            <m> \int_1^4 \frac{1}{\sqrt{4-x}} dx = 2\sqrt{3} </m>
           </p>
         </li>
 
@@ -169,9 +169,9 @@
         <li permid="DGa">
           <p permid="uWi">
             <md permid="EpU">
-              <mrow>\int_0^4 \frac{1}{\sqrt{4-x}} dx \amp = \lim_{b \to 4^-}\int_0^b \frac{1}{\sqrt{4-x}} dx</mrow>
-              <mrow>\amp = \lim_{b \to 4^-} \left. -2\sqrt{4-x} \right|_0^b</mrow>
-              <mrow>\amp = 4</mrow>
+              <mrow>\int_1^4 \frac{1}{\sqrt{4-x}} dx \amp = \lim_{b \to 4^-}\int_1^b \frac{1}{\sqrt{4-x}} dx</mrow>
+              <mrow>\amp = \lim_{b \to 4^-} \left. -2\sqrt{4-x} \right|_1^b</mrow>
+              <mrow>\amp = 2\sqrt{3}</mrow>
             </md>
           </p>
         </li>

--- a/source/activities/act-8-5-1.xml
+++ b/source/activities/act-8-5-1.xml
@@ -118,7 +118,7 @@
       <ol marker="a." permid="daV">
 	<li permid="ZaW">
           <p permid="GXs">
-            <ol label="i." permid="ppn">
+            <ol marker="i." permid="ppn">
               <li permid="jAb">
                 <p permid="wyn">
                   <m>
@@ -143,8 +143,8 @@
               <li permid="gjW">
                 <p permid="nOv">
                   <m>
-                  f^{k}(0) = 0 \text{ if } k \text{ is odd,
-                  and } f^{2k}(0) = (-1)^k
+                  f^{(k)}(0) = 0 \text{ if } k \text{ is odd,
+                  and } f^{(2k)}(0) = (-1)^k
                   </m>.
                 </p>
               </li>
@@ -171,7 +171,7 @@
               <li permid="XlJ">
                 <p permid="Qre">
                   <m>
-                  f^{k}(0) = 0 \text{ if } k \text{ is even } \ \ \ \text{ and } \ \ \ f^{2k+1}(0) = (-1)^k
+                  f^{(k)}(0) = 0 \text{ if } k \text{ is even } \ \ \ \text{ and } \ \ \ f^{(2k+1)}(0) = (-1)^k
                   </m>.
                 </p>
               </li>
@@ -200,7 +200,7 @@
       <ol marker="a." permid="kFu">
         <li permid="MME">
           <p permid="rOu">
-            <ol label="i." permid="wTM">
+            <ol marker="i." permid="wTM">
               <li permid="Urd">
                 <p permid="IMF">
                   The first four derivatives of <m>f(x)</m> at <m>x=0</m> are
@@ -249,8 +249,8 @@
                   <m>\pm \cos(x)</m> and have alternating values of 1 and <m>-1</m> at <m>x-0</m>.
                   Since the even numbers can be represented in the form <m>2k</m> where <m>k</m> is an integer we have
                   <me permid="lZi">
-                    f^{k}(0) = 0 \text{ if }  k \text{ is odd,
-                    and } f^{2k}(0) = (-1)^k
+                    f^{(k)}(0) = 0 \text{ if }  k \text{ is odd,
+                    and } f^{(2k)}(0) = (-1)^k
                   </me>.
                 </p>
               </li>
@@ -289,7 +289,7 @@
                   <m>\pm \cos(x)</m> and have alternating values of 1 and <m>-1</m> at <m>x-0</m>.
                   Since the odd numbers can be represented in the form <m>2k+1</m> where <m>k</m> is an integer we have
                   <me permid="KBS">
-                    f^{k}(0) = 0 \text{ if }  k \text{ is even }  \ \ \ \text{ and }  \ \ \ f^{2k+1}(0) = (-1)^k
+                    f^{(k)}(0) = 0 \text{ if }  k \text{ is even }  \ \ \ \text{ and }  \ \ \ f^{(2k+1)}(0) = (-1)^k
                   </me>.
                 </p>
               </li>

--- a/source/activities/act-8-5-1.xml
+++ b/source/activities/act-8-5-1.xml
@@ -116,6 +116,27 @@
   <answer permid="Yrc">
     <p permid="VaX">
       <ol marker="a." permid="daV">
+	<li permid="ZaW">
+          <p permid="GXs">
+            <ol label="i." permid="ppn">
+              <li permid="jAb">
+                <p permid="wyn">
+                  <m>
+                  f^{(k)}(0) = k!
+                  </m>.
+                </p>
+              </li>
+
+              <li permid="PHk">
+                <p permid="neB">
+                  <me permid="FRZ">
+                    P_n(x) = \sum_{k=0}^n  x^k
+                  </me>.
+                </p>
+              </li>
+            </ol>
+          </p>
+        </li>
         <li permid="KXr">
           <p permid="iuI">
             <ol marker="i." permid="YFx">
@@ -171,33 +192,46 @@
           </p>
         </li>
 
-        <li permid="ZaW">
-          <p permid="GXs">
-            <ol marker="i." permid="ppn">
-              <li permid="jAb">
-                <p permid="wyn">
-                  <m>
-                  f^{(k)}(0) = k!
-                  </m>.
-                </p>
-              </li>
-
-              <li permid="PHk">
-                <p permid="neB">
-                  <me permid="FRZ">
-                    P_n(x) = \sum_{k=0}^n  x^k
-                  </me>.
-                </p>
-              </li>
-            </ol>
-          </p>
-        </li>
       </ol>
     </p>
   </answer>
   <solution permid="sjT">
     <p permid="oTO">
       <ol marker="a." permid="kFu">
+        <li permid="MME">
+          <p permid="rOu">
+            <ol label="i." permid="wTM">
+              <li permid="Urd">
+                <p permid="IMF">
+                  The first four derivatives of <m>f(x)</m> at <m>x=0</m> are
+                  <md permid="PlL">
+                    <mrow>f(x) \amp = \frac{1}{1-x} \amp    f(0) \amp = 1</mrow>
+                    <mrow>f'(x) \amp = \frac{1}{(1-x)^2} \amp    f'(0) \amp = 1</mrow>
+                    <mrow>f''(x) \amp = \frac{2}{(1-x)^3} \amp     f''(0) \amp = 2</mrow>
+                    <mrow>f^{(3)}(x) \amp = \frac{3!}{(1-x)^4} \amp     f^{(3)}(0) \amp = 3!</mrow>
+                    <mrow>f^{(4)}(x) \amp = \frac{4!}{(1-x)^5} \amp    f^{(4)}(0) \amp = 4!</mrow>
+                  </md>.
+                  It appears that the pattern is
+                  <me permid="jeC">
+                    f^{(k)}(0) = k!
+                  </me>.
+                </p>
+              </li>
+
+              <li permid="Aym">
+                <p permid="XVD">
+                  The <m>n</m>th order Taylor polynomial for <m>f</m> at <m>x=0</m> is
+                  <me permid="vsU">
+                    \sum_{k=0}^n \frac{f^{(k)}}{k!} x^k = \sum_{k=0}^n \frac{k!}{k!} x^k = \sum_{k=0}^n  x^k
+                  </me>.
+                  This makes sense since <m>f(x)</m> is the sum of the geometric series with ratio <m>x</m>,
+                  so the <m>n</m>th order Taylor polynomial should just be the <m>n</m>th partial sum of this geometric series.
+                </p>
+              </li>
+            </ol>
+          </p>
+        </li>
+
         <li permid="vOt">
           <p permid="TlK">
             <ol marker="i." permid="EMG">
@@ -271,40 +305,6 @@
                     x - \frac{x^3}{3!} + \frac{x^5}{5!} - \frac{x^7}{7!} + \cdots + (-1)^{n/2+1}\frac{x^{n-1}}{(n-1)!}
                   </me>
                   if <m>n</m> is even.
-                </p>
-              </li>
-            </ol>
-          </p>
-        </li>
-
-        <li permid="MME">
-          <p permid="rOu">
-            <ol marker="i." permid="wTM">
-              <li permid="Urd">
-                <p permid="IMF">
-                  The first four derivatives of <m>f(x)</m> at <m>x=0</m> are
-                  <md permid="PlL">
-                    <mrow>f(x) \amp = \frac{1}{1-x} \amp    f(0) \amp = 1</mrow>
-                    <mrow>f'(x) \amp = \frac{1}{(1-x)^2} \amp    f'(0) \amp = 1</mrow>
-                    <mrow>f''(x) \amp = \frac{2}{(1-x)^3} \amp     f''(0) \amp = 2</mrow>
-                    <mrow>f^{(3)}(x) \amp = \frac{3!}{(1-x)^4} \amp     f^{(3)}(0) \amp = 3!</mrow>
-                    <mrow>f^{(4)}(x) \amp = \frac{4!}{(1-x)^5} \amp    f^{(4)}(0) \amp = 4!</mrow>
-                  </md>.
-                  It appears that the pattern is
-                  <me permid="jeC">
-                    f^{(k)}(0) = k!
-                  </me>.
-                </p>
-              </li>
-
-              <li permid="Aym">
-                <p permid="XVD">
-                  The <m>n</m>th order Taylor polynomial for <m>f</m> at <m>x=0</m> is
-                  <me permid="vsU">
-                    \sum_{k=0}^n \frac{f^{(k)}}{k!} x^k = \sum_{k=0}^n \frac{k!}{k!} x^k = \sum_{k=0}^n  x^k
-                  </me>.
-                  This makes sense since <m>f(x)</m> is the sum of the geometric series with ratio <m>x</m>,
-                  so the <m>n</m>th order Taylor polynomial should just be the <m>n</m>th partial sum of this geometric series.
                 </p>
               </li>
             </ol>


### PR DESCRIPTION
I noticed the typo on "volume" in the fall, and two of my students noticed the missing 2 in the activity answer this spring. It was also in the solution. The exact and approximate values are for the correct integrand, so it's just that 2 needs to be inserted in the right places.