### PR TITLE
Tie exercise Jwq more directly to the physical context

### DIFF
--- a/src/exercises/ez-5-1.xml
+++ b/src/exercises/ez-5-1.xml
@@ -56,14 +56,14 @@
 
           <li permid="lDA">
             <p permid="qXn">
-              On what interval(s) is <m>s</m> increasing? That is, when is the particle moving forward?
+              On what interval(s) is <m>s</m> increasing? That is, when is the particle moving forward? <br/>
               On what interval(s) is <m>s</m> decreasing? That is, when is the particle moving backward?
             </p>
           </li>
 
           <li permid="RKJ">
             <p permid="Xew">
-              On what interval(s) is <m>s</m> concave up? That is, when is the particle accelerating?
+              On what interval(s) is <m>s</m> concave up? That is, when is the particle accelerating? <br/>
               On what interval(s) is <m>s</m> concave down? That is, when is the particle decelerating?
             </p>
           </li>

--- a/src/exercises/ez-5-1.xml
+++ b/src/exercises/ez-5-1.xml
@@ -50,20 +50,21 @@
             <p permid="KQe">
               Use the given information to determine <m>s(1)</m>,
               <m>s(3)</m>, <m>s(5)</m>, and <m>s(6)</m>.
+              What do these values mean in the context of the moving particle?
             </p>
           </li>
 
           <li permid="lDA">
             <p permid="qXn">
-              On what interval(s) is <m>s</m> increasing?
-              On what interval(s) is <m>s</m> decreasing?
+              On what interval(s) is <m>s</m> increasing? That is, when is the particle moving forward?
+              On what interval(s) is <m>s</m> decreasing? That is, when is the particle moving backward?
             </p>
           </li>
 
           <li permid="RKJ">
             <p permid="Xew">
-              On what interval(s) is <m>s</m> concave up?
-              On what interval(s) is <m>s</m> concave down?
+              On what interval(s) is <m>s</m> concave up? That is, when is the particle accelerating?
+              On what interval(s) is <m>s</m> concave down? That is, when is the particle decelerating?
             </p>
           </li>
 


### PR DESCRIPTION
I'm proposing a couple of changes to the wording of the exercise with permid Jwq (it's exercise 5 in the current html build). The context of this exercise is that a moving particle has its velocity given by a particular graph with some areas indicated. I embroidered a couple of the questions with some more physical language (e.g., when is the particle moving forward / backward) to give students a stronger nudge to make those connections.

Note: I'm kinda diffident about the wording of the ones I wrote about concave up vs. concave down.

Note 2: I realized after I edited my file that there probably need to be <br />s at the ends of lines 59 and 66.