### PR TITLE
Add ? instead of empty choice in PA 8.1.1 PopUp

### DIFF
--- a/source/previews/PA-8a-1.xml
+++ b/source/previews/PA-8a-1.xml
@@ -28,7 +28,7 @@
       Context("Interval")->flags->set(tolType => 'absolute', tolerance => 0.051);
       $interval = Interval(-0.5, 0.5);
       $popup = PopUp([
-        "",
+        "?",
         "quadratic",
         "sine",
         "cosine",


### PR DESCRIPTION
The problem is getting stuck on loading for resubmits because of the empty first answer... adding a ? to that option should take care of it, since other problems like that are acting fine.  