### PR TITLE
Better ICs in baby weight problem

### DIFF
--- a/source/exercises/ez-7-5.xml
+++ b/source/exercises/ez-7-5.xml
@@ -434,7 +434,7 @@
 
           <li permid="qvX">
             <p permid="nfS">
-              Suppose that a baby weighs 8 pounds at birth and 9 pounds one month later.
+              Suppose that a baby weighs 8 pounds at birth and 10 pounds one month later.
               How much will he weigh at one year?
             </p>
           </li>
@@ -461,8 +461,8 @@
           <li permid="iRy">
             <p permid="fBt">
               <m>
-              w(t) = \sqrt{17t+64}
-              </m>; <m>w(12) = \sqrt{268} \approx 16.37</m> pounds.
+              w(t) = \sqrt{36t+64}
+              </m>; <m>w(12) = \sqrt{496} \approx 22.27</m> pounds.
             </p>
           </li>
 
@@ -490,7 +490,7 @@
 
           <li permid="bmZ">
             <p permid="XWU">
-              Given that <m>W(0) = 8</m> and <m>W(1) = 9</m>,
+              Given that <m>W(0) = 8</m> and <m>W(1) = 10</m>,
               we can both solve the IVP and determine <m>k</m>.
               To start, we separate variables and solve the differential equation by writing
               <me permid="ANY">
@@ -512,27 +512,27 @@
                 w(t) = \sqrt{2kt + 64}
               </me>.
               To find <m>k</m>,
-              we use the additional information that <m>w(1) = 9</m>, so
+              we use the additional information that <m>w(1) = 10</m>, so
               <me permid="ZqI">
-                9 = \sqrt{2k + 64}
+                10 = \sqrt{2k + 64}
               </me>
-              which implies that <m>81 = 2k + 64</m> and thus <m>k = 17/2</m>.
+              which implies that <m>100 = 2k + 64</m> and thus <m>k = 18</m>.
               Thus,
               <me permid="FxR">
-                w(t) = \sqrt{17t+64}
+                w(t) = \sqrt{36t+64}
               </me>.
               At one year,
-              according to the model the baby weighs <m>w(12) = \sqrt{268} \approx 16.37</m> pounds.
+              according to the model the baby weighs <m>w(12) = \sqrt{496} \approx 22.27</m> pounds.
             </p>
           </li>
 
           <li permid="Hui">
             <p permid="Eed">
-              While the function <m>w(t) = \sqrt{7t+64}</m> grows without bound as <m>t</m> increases,
+              While the function <m>w(t) = \sqrt{36t+64}</m> grows without bound as <m>t</m> increases,
               the model is unrealistic more because the function initially doesn't grow fast enough.
               For example, the model predicts that at age <m>10</m>,
-              <m>w(120) \approx 30.06</m> pounds,
-              and at age <m>20</m>, <m>w(120) = 41.76</m> pounds.
+              <m>w(120) \approx 66.22</m> pounds,
+              and at age <m>20</m>, <m>w(240) = 93.29</m> pounds.
               A realistic model would need to grow much more quickly early in life and then level off around age <m>20</m>.
             </p>
           </li>


### PR DESCRIPTION
A student of mine objected to the prediction of the one-year-old's weight as 16 lb. I looked at some 50th percentile baby weight data and found that w(0) = 8, w(1) = 10 produces a better fit and more sensible predictions within the first year or two.

https://www.parents.com/first-year-infant-growth-chart-8546333