### PR TITLE
typo fixes in proteus 2.3

### DIFF
--- a/source/proteus/proteus-2-3.xml
+++ b/source/proteus/proteus-2-3.xml
@@ -35,6 +35,8 @@
       <response>The sum of two products</response>
     </match>
     <match>
+      <!-- Renders fine in Firefox on Windows and Linux -->
+      <!-- Too wide in Firefox on Mac -->
       <premise order="4"><m>\small{g(x) = (\sin(x) + \cos(x)) \cdot (e^x + \sqrt{x})}</m></premise>
       <response>The product of two sums</response>
     </match>
@@ -48,13 +50,16 @@
     </match>
     <match>
       <premise order="3"><m>s(x) = \dfrac{\sin(x)}{e^x} + \dfrac{\cos(x)}{\sqrt{x}}</m></premise>
+      <response>The sum of two quotients</response>
+    </match>
+    <match>
+      <response>The quotient of two sums</response>
+    </match>
+    <match>
+      <response>The difference of a quotient and a product</response>
+    </match>
+    <match>
       <response>The sum of a quotient and a product</response>
-    </match>
-    <match>
-      <response>the quotient of two sums</response>
-    </match>
-    <match>
-      <response>the difference of a quotient and a product</response>
     </match>
   </matches>
 </exercise>
@@ -92,39 +97,39 @@
   </statement>
   <matches>
     <match>
-    <premise order="8"><m>N(t)</m></premise>
-    <response>dollars per day</response>
-    </match>
-    <match>
-    <premise order="4"><m>N'(t)</m></premise>
-    <response>(dollars per day) / day</response>
-    </match>
-    <match>
-    <premise order="2"><m>C(t)</m></premise>
-    <response>dollars <m>\cdot</m> dollars</response>
-    </match>
-    <match>
-    <premise order="5"><m>C'(t)</m></premise>
-    <response>(dollars / day) / day</response>
-    </match>
-    <match>
-    <premise order="6"><m>N(t) \cdot C'(t)</m></premise>
-    <response>(apples per day) per day</response>
-    </match>
-    <match>
-    <premise order="3"><m>C(t) \cdot N'(t)</m></premise>
-    <response>(dollars per apple) per day</response>
-    </match>
-    <match>
-    <premise order="1"><m>A(t)</m></premise>
-    <response>dollars / apple</response>
-    </match>
-    <match>
-    <premise order="7"><m>A'(t)</m></premise>
-    <response>(dollars / day) per day</response>
-    </match>
-    <match>
+      <premise order="8"><m>N(t)</m></premise>
       <response>apples per day</response>
+    </match>
+    <match>
+      <premise order="4"><m>N'(t)</m></premise>
+      <response>(apples per day) / day</response>
+    </match>
+    <match>
+      <premise order="2"><m>C(t)</m></premise>
+      <response>dollars / apple</response>
+    </match>
+    <match>
+      <premise order="5"><m>C'(t)</m></premise>
+      <response>(dollars per apple) / day</response>
+    </match>
+    <match>
+      <premise order="6"><m>N(t) \cdot C'(t)</m></premise>
+      <response>(dollars per day) per day</response>
+    </match>
+    <match>
+      <premise order="3"><m>C(t) \cdot N'(t)</m></premise>
+      <response>(dollars per day) per day</response>
+    </match>
+    <match>
+      <premise order="1"><m>A(t)</m></premise>
+      <response>dollars / day</response>
+    </match>
+    <match>
+      <premise order="7"><m>A'(t)</m></premise>
+      <response>(dollars per day) per day</response>
+    </match>
+    <match>
+      <response>(dollars per apple) per apple</response>
     </match>
     <match>
       <response>apples per dollar</response>


### PR DESCRIPTION
I've made a bunch of small changes to the matching problems in 2.3. There were a bunch of incorrect responses in match pairs. I also updated a couple of distractors in proteus-matching-cost-apples.