### PR TITLE
Move PROTEUS to use 8a

### DIFF
--- a/publication/publication-proteus.ptx
+++ b/publication/publication-proteus.ptx
@@ -1,6 +1,6 @@
 <publication>
   <source>
-    <version include="proteus ed1 static"/>
+    <version include="proteus ed2 static"/>
     <directories external="../assets" generated="../generated-assets-proteus"
 		 />
   </source>

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -1,7 +1,7 @@
 <publication>
   <source>
     <directories external="../assets" generated="../generated-assets-ed1" />
-    <version include="ed1 production static ed1-static" />
+    <version include="ed1 production static" />
   </source>
   <html>
     <css theme="default-modern" palette="blues" />

--- a/publication/publication_ed2.ptx
+++ b/publication/publication_ed2.ptx
@@ -1,7 +1,7 @@
 <publication>
   <source>
     <directories external="../assets" generated="../generated-assets-ed2" />
-    <version include="ed2 production static" />
+    <version include="ed2 production static ed2-static" />
   </source>
   <html>
     <css theme="default-modern" palette="blues" />

--- a/source/bookinfo.xml
+++ b/source/bookinfo.xml
@@ -56,9 +56,8 @@
   <cross-references text="global" />
   <initialism>AC</initialism>
 
-  <document-id component="ed2" edition="2">ac-single</document-id>
-  <document-id component="ed1-static" edition="1">ac-single</document-id>
-  <document-id component="proteus" edition="1">active-calc-proteus</document-id>
+  <document-id component="runestone" edition="2">ac-single</document-id>
+  <document-id component="proteus" edition="2">active-calc-proteus</document-id>
   <blurb shelf="Mathematics">
     Active Calculus Single Variable supports an active learning approach in the first two semesters of calculus. Every section of Active Calculus Single Variable offers engaging activities for students to complete before and during class; additional exercises that challenge students to connect and assimilate core concepts; interactive WeBWorK exercises; opportunities for students to develop conceptual understanding and improve their skills at communicating mathematical idea.  The text is free and open-source, available in HTML, PDF, and print formats.  Ancillary materials for instructors are also available.
   </blurb>

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -18,8 +18,9 @@
   <book permid="qaP">
     <title>Active Calculus</title>
     <subtitle component="proteus">PROTEUS Version</subtitle>
-    <subtitle component="ed2">2nd Ed</subtitle>
-    <subtitle component="ed1-static">1st Ed</subtitle>
+    <subtitle component="ed2-static">2nd Ed</subtitle>
+    <subtitle component="runestone">2nd Ed</subtitle>
+    <subtitle component="ed1">1st Ed</subtitle>
     <xi:include href="./frontmatter.xml" />
 
     <xi:include href="./chap-1.xml" />


### PR DESCRIPTION
This moves the `proteus` build target to use chapter 8a (and anything else that gets tagged for `ed2`).