### PR TITLE
name change for Runestone supplementary material

### DIFF
--- a/publication/publication-proteus-sandbox.ptx
+++ b/publication/publication-proteus-sandbox.ptx
@@ -1,6 +1,6 @@
 <publication>
   <source>
-    <version include="proteus-sandbox ed2 runestone online"/> <!-- including both proteus and proteus-sandbox -->
+    <version include="proteus-sandbox ed2 runestone online supplementary-ww"/> <!-- including both proteus and proteus-sandbox -->
     <directories  generated="../generated-assets-proteus"
 		 />
   </source>

--- a/publication/publication-proteus.ptx
+++ b/publication/publication-proteus.ptx
@@ -1,6 +1,6 @@
 <publication>
   <source>
-    <version include="proteus ed2 runestone online"/>
+    <version include="proteus ed2 runestone online supplementary-ww"/>
     <directories  generated="../generated-assets-proteus"
 		 />
   </source>

--- a/publication/publication_doenet.ptx
+++ b/publication/publication_doenet.ptx
@@ -1,7 +1,7 @@
 <publication>
   <source>
     <directories generated="../generated-assets-runestone" />
-    <version include="doenet ed2 online" />
+    <version include="doenet ed2 online supplementary-ww" />
   </source>
   <html>
     <brandlogo url="https://activecalculus.org" source="images/ACS2E-cover.png"/>

--- a/publication/publication_runestone.ptx
+++ b/publication/publication_runestone.ptx
@@ -1,7 +1,7 @@
 <publication>
   <source>
     <directories  generated="../generated-assets-runestone" />
-    <version include="runestone ed2 online exercises-ww" />
+    <version include="runestone ed2 online exercises-ww supplementary-ww" />
   </source>
   <html>
     <css theme="default-modern" palette="blues" />

--- a/source/safranski.xml
+++ b/source/safranski.xml
@@ -11,7 +11,7 @@
 <!-- "share and share alike".  All trademarks are the registered marks of  -->
 <!-- their respective owners.                                              -->
 <!-- **********************************************************************-->
-<chapter xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="C-safranski" component="runestone">
+<chapter xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="C-safranski" component="supplementary-ww">
   <title>Supplementary material</title>
   <section xml:id="sec-safranski-review1">
     <title>Review of Prerequsites for Calculus I</title>


### PR DESCRIPTION
Changed the component name of the supplementary chapter and then modified the doenet publication file to include the new component.  Also modified each publication file which includes the runestone component to also include the new component name.  I built and checked that the doenet version now includes Chapter 9.